### PR TITLE
[fix] Enable interpretation when echoing /etc/hosts

### DIFF
--- a/cli/setup-hosts-file.sh
+++ b/cli/setup-hosts-file.sh
@@ -26,7 +26,7 @@ if [ ${QUESTION} == "a" ]; then
 		echo -e ${YELLOW}"$HOSTNAME already exists: $(grep $HOSTNAME $ETC_HOSTS) ${NC}"
 	else
 		echo -e ${GREEN}"Adding $HOSTNAME to your $ETC_HOSTS ${NC}"
-		sudo -- sh -c -e "echo '$HOSTS_LINE' >> /etc/hosts"
+		sudo -- sh -c -e "echo -e '$HOSTS_LINE' >> /etc/hosts"
 
 		if [ -n "$(grep $HOSTNAME /etc/hosts)" ]; then
 			echo -e ${GREEN}"$HOSTNAME was added succesfully \n $(grep $HOSTNAME /etc/hosts) ${NC}"


### PR DESCRIPTION
First of all thanks for your starter, saves me a lot of time! 

There's currently a little bug in the `cli/setup-hosts-file.sh` script, which causes hosts to be added wrongly. This PR adds the -e parameter to `echo`, enabling the tab `\t` to be handled correctly. 