### PR TITLE
Create wp-cli cache dir.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ FROM urre/wordpress-nginx-docker-compose-image
 RUN curl -o /bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 RUN chmod +x /bin/wp-cli.phar
 RUN cd /bin && mv wp-cli.phar wp
+RUN mkdir -p /var/www/.wp-cli/cache && chown www-data:www-data /var/www/.wp-cli/cache
 
 # Note: Use docker-compose up -d --force-recreate --build when Dockerfile has changed.


### PR DESCRIPTION
Resolves permission issues with the cache directory creation inside the container during updates.