### PR TITLE
CHANGED composer base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: always
 
   composer:
-    image: composer/composer
+    image: composer
     container_name: myapp-composer
     working_dir: /var/www/html
     restart: 'no'


### PR DESCRIPTION
The image `composer/composer` has been deprecated. It is suggested to use the official image `composer`