### PR TITLE
Removed unnecessary IP variable from phpmyadmin ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       PMA_PORT: 3306
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
     ports:
-      - ${IP}:8080:80
+      - '8080:80'
     links:
       - mysql:mysql
 


### PR DESCRIPTION
In the project's docker-compose file, phpymyadmin uses the IP variable (which is set to 127.0.0.1) followed by the ports it needs to use. Because of that, starting a docker container causes an error:

`"services.phpmyadmin.ports contains an invalid type, it should be a number, or an object".`

Removing the IP variable from the ports fixes the issue.