### PR TITLE
Use env var on db password setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ cd cli
 ## Install WordPress and Composer dependencies
 
 ```shell
-cd src
 docker-compose run composer install
 ```
 > If you have Composer installed on your computer you can also use `cd src && composer install`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ Copy `.env-example` in the `src` folder to `.env` and edit your preferences.
 Use the following database settings:
 
 ```dotenv
-DB_HOST=mysql:3306
+APP_NAME=myapp
+DOMAIN=myapp.local
+DB_ROOT_PASSWORD=password
+DB_HOST=mysql
 DB_NAME=myapp
 DB_USER=root
 DB_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     volumes:
        - './data/db:/var/lib/mysql:delegated'
     environment:
-      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
       - MYSQL_DATABASE=${DB_NAME}
     restart: always
     ports:

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,4 +1,7 @@
-DB_HOST=mysql:3306
+APP_NAME=myapp
+DOMAIN=myapp.local
+DB_ROOT_PASSWORD=password
+DB_HOST=mysql
 DB_NAME=myapp
 DB_USER=root
 DB_PASSWORD=password


### PR DESCRIPTION
The password setup for the mariadb container  do not currently use the env var.