### PR TITLE
Update create-cert.sh "-days 3650" to "-days 365"

### DIFF
--- a/cli/create-cert.sh
+++ b/cli/create-cert.sh
@@ -33,7 +33,7 @@ openssl req \
     -config <(cat $OPENSSL_CNF_PATH \
         <(printf '[SAN]\nsubjectAltName=DNS:'${DOMAIN})) \
     -sha256 \
-    -days 3650
+    -days 365
 
 rm -rf ../certs/*
 mkdir -p ../certs


### PR DESCRIPTION
I modified my local copy from "-days 3650" to "-days 365" so I didn't have to look at Chrome "Not Secure" warning due to Chrome not trusting certs over 398 days. I thought other newcomers might want to skip that hurdle, avoid the confusion, and see the lock.
https://www.leaderssl.com/news/511-starting-1-september-2020-chrome-will-no-longer-trust-any-certificates-older-than-one-year
https://www.ssl.com/blogs/398-day-browser-limit-for-ssl-tls-certificates-begins-september-1-2020/